### PR TITLE
Add a pytest suite and ruff config, fix three bugs it uncovered

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Docker image
+name: CI
 
 on:
   push:
@@ -10,7 +10,40 @@ on:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Lowest version the package claims to support, the one the Dockerfile
+        # uses, and the newest stable one.
+        python-version: ["3.10", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install the package with its dev extra
+        run: python -m pip install -e '.[dev]'
+
+      - name: Lint
+        # The linter is version independent, so run it once instead of 3 times.
+        if: matrix.python-version == '3.12'
+        run: ruff check .
+
+      - name: Run the test suite
+        run: pytest
+
   build-and-push:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 /.DS_Store
 /.venv
-/__pycache__
+__pycache__/
 /sys-stats
 /build
 /dist
 *.egg-info/
 .qodo
+.pytest_cache/
+.ruff_cache/
+.agent.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+
+
+
+
+
+
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`sys-stats` is a real-time system / GPU / Ollama monitoring dashboard, shipped as a
+single installable Python package (`src/sys_stats`, hatchling, src-layout) exposing
+two console scripts:
+
+| Script             | Module              | Role                                          |
+| ------------------ | ------------------- | --------------------------------------------- |
+| `sys-stats-server` | `sys_stats.server`  | Flask API + web UI, serves `/` and `/stats`    |
+| `sys-stats`        | `sys_stats.cli`     | Rich terminal dashboard, HTTP **client** of `/stats` |
+
+`python -m sys_stats` is an alias for the CLI.
+
+## Architecture
+
+Everything hinges on one contract: the JSON payload returned by `GET /stats`.
+
+- **Server side** ([server.py](src/sys_stats/server.py)) is the only place that touches the
+  machine. It gathers metrics from three unrelated sources and merges them into one
+  response:
+  - `psutil` for CPU / RAM / top processes,
+  - `GPUtil` for GPU enumeration, plus **direct `nvidia-smi` subprocess calls**
+    (`get_gpu_fan_and_power`, `get_gpu_processes`) for fan speed, power draw and
+    per-process VRAM, which GPUtil does not expose. These parse CSV
+    (`--format=csv,noheader,nounits`) and must degrade to `[]`/`{}` when the binary
+    is missing or fails.
+  - Ollama's `/api/ps`, only when `OLLAMA_API_URL` is set (otherwise it returns an
+    empty `{"models": []}` — never an error).
+- **Two independent consumers** of that payload: the inline JS in
+  [templates/index.html](src/sys_stats/templates/index.html) (no build step, no bundler,
+  no external JS deps) and the Rich CLI. **Changing a key in the `/stats` response
+  means updating both**, plus the CLI's `build_*_panel` functions.
+- Units are deliberately normalised server-side: memory is converted to **bytes**
+  before leaving `/stats` (GPUtil hands out MiB), `load` is a percentage, `powerDraw`
+  is watts. The CLI's `human_readable_size` assumes bytes.
+
+### CLI concurrency model
+
+[cli.py](src/sys_stats/cli.py) runs a `readchar` keyboard listener in a daemon thread
+alongside the main `rich.live.Live` render loop. Shared state (`is_paused`,
+`show_help_flag`, `refresh_interval`, `latest_stats`) lives in module-level globals
+guarded by `state_lock` / `stats_lock`, with `exit_event` and `rebuild_layout_event`
+for signalling. The sleep between refreshes is sliced into 100 ms chunks so key
+presses feel instant. Any new interactive feature goes through the same
+event + lock pattern, not through busy-waiting or a second render loop.
+
+## Commands
+
+```bash
+# Dev install (editable, with pytest + ruff)
+uv venv && source .venv/bin/activate && uv pip install -e '.[dev]'
+
+# Tests and lint
+pytest                                 # whole suite
+pytest tests/test_stats_endpoint.py    # one file
+pytest -k gpu_processes                # one test / group
+ruff check .                           # add --fix to autofix
+
+# Run the two halves
+sys-stats-server                       # HOST / PORT / FLASK_DEBUG env vars
+sys-stats --url http://localhost:5000/stats --interval 5
+
+# Docker
+docker compose up -d                                    # no GPU
+docker compose -f compose.yaml -f compose.gpu.yaml up -d # NVIDIA
+
+# Standalone binary of the CLI
+./nuitka.sh                            # outputs build/sys-stats
+```
+
+On macOS port 5000 is taken by AirPlay Receiver — run the server with `PORT=5051`
+when smoke-testing locally.
+
+### Testing conventions
+
+No test touches the real machine: `psutil`, `GPUtil`, `subprocess.run` and
+`requests.get` are all monkeypatched at the `sys_stats.server` module boundary.
+[tests/test_stats_endpoint.py](tests/test_stats_endpoint.py) is the contract test for
+the `/stats` payload — if you add or rename a key there, that file is the one that
+must change first. Two classes of failure matter most and are already covered:
+unit conversions (MiB → bytes, fraction → percent) and graceful degradation when a
+collector returns nothing.
+
+Beware `psutil.process_iter(attrs)`: it does **not** raise on permission errors, it
+fills the unreadable attributes with `None`. Any new field read from it needs a
+`None` guard, otherwise sorting or arithmetic turns the whole endpoint into a 500 on
+unprivileged hosts.
+
+## Environment variables
+
+| Variable             | Consumed by | Effect                                          |
+| -------------------- | ----------- | ----------------------------------------------- |
+| `OLLAMA_API_URL`     | server      | Enables the Ollama panel; unset ⇒ panel empty   |
+| `HOST` / `PORT`      | server      | Bind address, default `0.0.0.0:5000`            |
+| `FLASK_DEBUG`        | server      | `true` enables Flask debug mode                 |
+| `SYS_STATS_API_URL`  | CLI         | Default `--url`, default `http://localhost:5000/stats` |
+
+## Deployment constraints worth knowing
+
+- The container needs `pid: host` and `privileged: true` (see [compose.yaml](compose.yaml))
+  to see the host's processes — process listings are meaningless without it.
+- The Dockerfile intentionally builds on the **full** `python:3.12` image (not slim/uv):
+  the CI matrix targets `linux/amd64,arm64,i386,arm/v7` and `psutil` must compile from
+  source on the exotic arches. Don't "optimise" that back to slim without checking the
+  workflow's platform list.
+- [.github/workflows/build-and-publish.yaml](.github/workflows/build-and-publish.yaml)
+  pushes and cosign-signs to both `ghcr.io/obeone/sys-stats` and
+  `docker.io/obeoneorg/sys-stats` on `main` only; PRs build without pushing.
+- [compose/](compose/) is a Kompose-generated Helm chart (chart name `compose`), not
+  hand-written. Treat it as generated output.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,18 @@ whenever the virtual environment is activated.
    git clone https://github.com/obeone/sys-stats.git
    cd sys-stats
    uv venv && source .venv/bin/activate
-   uv pip install -e .
+   uv pip install -e '.[dev]'
    ```
+
+   The `[dev]` extra adds `pytest` and `ruff`. Run the checks with:
+
+   ```bash
+   pytest
+   ruff check .
+   ```
+
+   Note for macOS: port 5000 is used by AirPlay Receiver, so start the server
+   with `PORT=5051 sys-stats-server` if you don't want to disable it.
 
 2. **Configure environment variables (optional):**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dependencies = [
     "setuptools>=78.1; python_version >= '3.12'",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.6",
+]
+
 [project.urls]
 Homepage = "https://github.com/obeone/sys-stats"
 Repository = "https://github.com/obeone/sys-stats"
@@ -46,3 +52,15 @@ packages = ["src/sys_stats"]
 
 [tool.hatch.build.targets.sdist]
 include = ["src/sys_stats", "README.md", "LICENSE"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]

--- a/src/sys_stats/cli.py
+++ b/src/sys_stats/cli.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 
-import requests
-import time
 import argparse
-import shutil
 import os
+import shutil
 import threading
+import time
 from datetime import datetime, timedelta, timezone
-from rich.console import Console, Group
-from rich.live import Live
-from rich.table import Table
-from rich.panel import Panel
-from rich.layout import Layout
-from rich.text import Text
+
 import readchar  # To capture key presses
+import requests
+from rich.console import Console, Group
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
 
 # Default API URL
 SYS_STATS_API_URL = os.getenv('SYS_STATS_API_URL', 'http://localhost:5000/stats')
@@ -49,8 +49,13 @@ def fetch_stats(api_url):
 
 
 def human_readable_size(size):
-    """Converts bytes into a human-readable format."""
-    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+    """Converts bytes into a human-readable format.
+
+    ``TB`` is handled by the fallback rather than by the loop: a unit listed in
+    the loop gets divided once more before the fallback is reached, which would
+    under-report anything past a terabyte.
+    """
+    for unit in ['B', 'KB', 'MB', 'GB']:
         if size < 1024:
             return f"{size:.1f} {unit}"
         size /= 1024
@@ -144,11 +149,9 @@ def build_summary(data, interval):
 def build_gpu_summary(data):
     """Builds a summary panel for GPU information."""
     tables = []
-    
+
     if data.get("has_gpu") and data.get("gpu"):
         for gpu_data in data['gpu']:
-
-            gpu_data = data['gpu'][0]
             gpu_name = truncate_name(gpu_data.get('name', 'N/A'), 25)
             gpu_load = gpu_data.get('load', 0)
             gpu_fan_speed = gpu_data.get('fanSpeed', '')
@@ -167,7 +170,7 @@ def build_gpu_summary(data):
             vram_percent = memory_percent
 
             table = Table(title=gpu_name, show_header=False, padding=(0, 1), expand=True)
-            
+
             table.add_column(style='green')
             table.add_column()
             table.add_row('Total VRAM', memory_total_str)
@@ -176,7 +179,7 @@ def build_gpu_summary(data):
             table.add_row('Fan speed', f"{gpu_fan_speed:.0f} %")
             table.add_row('VRAM used', f"{memory_used_str} ({vram_percent:.2f} %)")
             table.add_row('Utilization', f"{gpu_load:.1f} %")
-            
+
             tables.append(table)
 
     return Group(*tables)
@@ -385,7 +388,12 @@ def main():
     global latest_stats
     parser = argparse.ArgumentParser(description="CLI for server statistics dashboard")
     parser.add_argument("--url", type=str, default=SYS_STATS_API_URL, help="API URL for the statistics")
-    parser.add_argument("--interval", type=int, default=5, help="Refresh interval in seconds (can be adjusted with '+' and '-')")
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=5,
+        help="Refresh interval in seconds (can be adjusted with '+' and '-')",
+    )
     args = parser.parse_args()
 
     global refresh_interval
@@ -422,7 +430,12 @@ def main():
                 else:
                     # If paused, only rebuild the layout with the latest data
                     if latest_stats:
-                        build_layout_content(layout, latest_stats, current_interval, terminal_width=shutil.get_terminal_size(fallback=(80, 20)).columns)
+                        build_layout_content(
+                            layout,
+                            latest_stats,
+                            current_interval,
+                            terminal_width=shutil.get_terminal_size(fallback=(80, 20)).columns,
+                        )
 
             # Check if a layout rebuild is required
             if rebuild_layout_event.is_set():
@@ -430,9 +443,19 @@ def main():
                     help_panel = build_full_screen_help()
                     layout.update(help_panel)
                 elif not paused and latest_stats:
-                    build_layout_content(layout, latest_stats, current_interval, terminal_width=shutil.get_terminal_size(fallback=(80, 24)).columns)
+                    build_layout_content(
+                        layout,
+                        latest_stats,
+                        current_interval,
+                        terminal_width=shutil.get_terminal_size(fallback=(80, 24)).columns,
+                    )
                 elif paused and latest_stats:
-                    build_layout_content(layout, latest_stats, current_interval, terminal_width=shutil.get_terminal_size(fallback=(80, 20)).columns)
+                    build_layout_content(
+                        layout,
+                        latest_stats,
+                        current_interval,
+                        terminal_width=shutil.get_terminal_size(fallback=(80, 20)).columns,
+                    )
                 rebuild_layout_event.clear()
 
             # Wait for the refresh interval or an event

--- a/src/sys_stats/server.py
+++ b/src/sys_stats/server.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
-import os
-import logging
-import psutil
-import subprocess
-from typing import List, Dict, Any
-from flask import Flask, jsonify, render_template, request, send_from_directory
-from flask_cors import CORS
-import GPUtil
-import coloredlogs
-import requests
 import datetime
+import logging
+import os
+import subprocess
+from typing import Any
 from urllib.parse import urljoin
 
+import coloredlogs
+import GPUtil
+import psutil
+import requests
+from flask import Flask, jsonify, render_template, request, send_from_directory
+from flask_cors import CORS
 
 OLLAMA_API_URL = os.getenv("OLLAMA_API_URL")
 
@@ -23,17 +22,22 @@ coloredlogs.install(level='INFO', logger=logger, fmt='%(asctime)s - %(levelname)
 app = Flask(__name__)
 CORS(app)
 
-def get_top_processes_by_cpu(limit: int = 5) -> List[Dict[str, Any]]:
+def get_top_processes_by_cpu(limit: int = 5) -> list[dict[str, Any]]:
     """
     Retrieve the top processes by CPU usage.
     """
     processes = []
     for p in psutil.process_iter(["pid", "name", "cpu_percent", "cmdline"]):
         try:
+            # ``process_iter`` does not raise for attributes it cannot read: it
+            # fills them with None. That is the common case for root-owned
+            # processes when the server runs unprivileged (macOS, container
+            # without `pid: host` + `privileged`), and sorting None against a
+            # float would blow up the whole endpoint.
             processes.append({
                 "pid": p.info["pid"],
                 "name": p.info["name"],
-                "cpu_percent": p.info["cpu_percent"],
+                "cpu_percent": p.info["cpu_percent"] or 0.0,
                 "cmdline": " ".join(p.info["cmdline"]) if p.info["cmdline"] else "N/A"
             })
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
@@ -43,18 +47,21 @@ def get_top_processes_by_cpu(limit: int = 5) -> List[Dict[str, Any]]:
     logger.debug(f"Top CPU processes: {processes[:limit]}")
     return processes[:limit]
 
-def get_top_processes_by_memory(limit: int = 5) -> List[Dict[str, Any]]:
+def get_top_processes_by_memory(limit: int = 5) -> list[dict[str, Any]]:
     """
     Retrieve the top processes by memory usage.
     """
     processes = []
     for p in psutil.process_iter(["pid", "name", "memory_percent", "memory_info", "cmdline"]):
         try:
+            # See get_top_processes_by_cpu: unreadable attributes come back as
+            # None, including the whole memory_info namedtuple.
+            memory_info = p.info["memory_info"]
             processes.append({
                 "pid": p.info["pid"],
                 "name": p.info["name"],
-                "memory_usage": p.info["memory_info"].rss,
-                "memory_percent": p.info["memory_percent"],
+                "memory_usage": memory_info.rss if memory_info else 0,
+                "memory_percent": p.info["memory_percent"] or 0.0,
                 "cmdline": " ".join(p.info["cmdline"]) if p.info["cmdline"] else "N/A"
             })
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
@@ -64,15 +71,18 @@ def get_top_processes_by_memory(limit: int = 5) -> List[Dict[str, Any]]:
     logger.debug(f"Top Memory processes: {processes[:limit]}")
     return processes[:limit]
 
-def get_gpu_processes(limit: int = 5) -> List[Dict[str, Any]]:
+def get_gpu_processes(limit: int = 5) -> list[dict[str, Any]]:
     """
     Retrieve the top GPU processes using nvidia-smi for process usage.
     """
     try:
         result = subprocess.run(
-            ['nvidia-smi', '--query-compute-apps=pid,process_name,used_memory', '--format=csv,noheader,nounits'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            [
+                'nvidia-smi',
+                '--query-compute-apps=pid,process_name,used_memory',
+                '--format=csv,noheader,nounits',
+            ],
+            capture_output=True,
             text=True,
             check=True
         )
@@ -110,7 +120,7 @@ def get_gpu_processes(limit: int = 5) -> List[Dict[str, Any]]:
     logger.debug(f"Top GPU processes: {gpu_processes[:limit]}")
     return gpu_processes[:limit]
 
-def get_gpu_fan_and_power() -> Dict[int, Dict[str, float]]:
+def get_gpu_fan_and_power() -> dict[int, dict[str, float]]:
     """
     Retrieve fan speed (%) and power draw (W) for each GPU via nvidia-smi.
     Returns a dict keyed by GPU index: {"fan_speed": float, "power_draw": float}.
@@ -119,8 +129,7 @@ def get_gpu_fan_and_power() -> Dict[int, Dict[str, float]]:
     try:
         result = subprocess.run(
             ['nvidia-smi', '--query-gpu=index,fan.speed,power.draw', '--format=csv,noheader,nounits'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             check=True
         )

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -1,0 +1,95 @@
+"""Tests for the pure formatting helpers of the terminal dashboard.
+
+These functions are the presentation contract of :mod:`sys_stats.cli`: they turn
+the raw byte counts and ISO timestamps returned by ``/stats`` into the strings
+rendered in the Rich tables.
+"""
+
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from sys_stats.cli import (
+    human_readable_size,
+    time_until,
+    truncate_cmdline,
+    truncate_name,
+)
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (0, "0.0 B"),
+        (512, "512.0 B"),
+        (1023, "1023.0 B"),
+        (1024, "1.0 KB"),
+        (1536, "1.5 KB"),
+        (1024**2, "1.0 MB"),
+        (1024**3, "1.0 GB"),
+        (1024**4, "1.0 TB"),
+    ],
+)
+def test_human_readable_size_scales_by_binary_unit(size, expected):
+    """Byte counts are rendered with the largest unit below 1024."""
+    assert human_readable_size(size) == expected
+
+
+def test_human_readable_size_caps_at_terabytes():
+    """Values beyond the unit table stay in TB rather than overflowing it."""
+    assert human_readable_size(5 * 1024**5) == "5120.0 TB"
+
+
+def test_truncate_cmdline_leaves_short_values_untouched():
+    """A command line shorter than the budget is returned verbatim."""
+    assert truncate_cmdline("python -m sys_stats", 40) == "python -m sys_stats"
+
+
+def test_truncate_cmdline_ellipsises_and_respects_width():
+    """A long command line is cut to exactly ``width`` characters, ellipsis included."""
+    result = truncate_cmdline("a" * 50, 10)
+
+    assert len(result) == 10
+    assert result.endswith("…")
+
+
+def test_truncate_name_uses_its_own_default_budget():
+    """Process names default to 15 characters, ellipsis included."""
+    assert truncate_name("short") == "short"
+
+    result = truncate_name("an-extremely-long-process-name")
+    assert len(result) == 15
+    assert result.endswith("…")
+
+
+def test_time_until_formats_a_future_deadline():
+    """A future expiry is rendered as a ``H:MM:SS`` countdown."""
+    expiration = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+
+    assert re.fullmatch(r"\d+:\d{2}:\d{2}", time_until(expiration))
+
+
+def test_time_until_accepts_the_zulu_suffix_ollama_returns():
+    """Ollama reports ``expires_at`` with a ``Z`` suffix, which must parse."""
+    expiration = (
+        (datetime.now(timezone.utc) + timedelta(hours=1))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+    assert re.fullmatch(r"\d+:\d{2}:\d{2}", time_until(expiration))
+
+
+def test_time_until_reports_expired_deadlines():
+    """A deadline in the past is flagged instead of showing a negative delta."""
+    expiration = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+
+    assert "Expired" in time_until(expiration)
+
+
+@pytest.mark.parametrize("value", ["", "not-a-date", "2024-13-45T99:99:99"])
+def test_time_until_falls_back_to_na_on_garbage(value):
+    """Unparsable timestamps degrade to ``N/A`` instead of raising."""
+    assert time_until(value) == "N/A"

--- a/tests/test_cli_panels.py
+++ b/tests/test_cli_panels.py
@@ -1,0 +1,110 @@
+"""Tests for the Rich panel builders of the terminal dashboard.
+
+The builders are pure: they take a ``/stats`` payload and return renderables, so
+they can be asserted on without a terminal. Only structure is checked here (how
+many tables, which rows), never the ANSI output.
+"""
+
+import pytest
+
+from sys_stats.cli import (
+    build_gpu_processes_panel,
+    build_gpu_summary,
+    build_ollama_panel,
+    build_process_table,
+)
+
+
+def _gpu(gpu_id: int, name: str) -> dict:
+    """Build a GPU entry shaped like the one ``/stats`` returns."""
+    return {
+        "id": gpu_id,
+        "name": name,
+        "load": 42.0,
+        "memoryUsed": 12288 * 1024 * 1024,
+        "memoryPercent": 50.0,
+        "temperature": 61.0,
+        "fanSpeed": 30.0,
+        "powerDraw": 220.0,
+    }
+
+
+class TestBuildGpuSummary:
+    def test_renders_one_table_per_gpu(self):
+        """Regression: every card gets its own table, not GPU 0 repeated N times."""
+        data = {
+            "has_gpu": True,
+            "gpu": [_gpu(0, "RTX 3090"), _gpu(1, "RTX 4090")],
+        }
+
+        titles = [table.title for table in build_gpu_summary(data).renderables]
+
+        assert titles == ["RTX 3090", "RTX 4090"]
+
+    def test_renders_nothing_without_a_gpu(self):
+        """A GPU-less host produces an empty group, not a placeholder table."""
+        assert build_gpu_summary({"has_gpu": False, "gpu": []}).renderables == []
+
+
+class TestBuildProcessTable:
+    @pytest.mark.parametrize(("key", "title"), [("top_cpu", "CPU"), ("top_memory", "Memory")])
+    def test_empty_rankings_render_a_placeholder_panel(self, key, title):
+        """No data yields an explanatory panel rather than an empty table."""
+        panel = build_process_table([], key, title)
+
+        assert title in str(panel.renderable)
+
+    def test_cpu_table_has_one_row_per_process(self):
+        """Each process becomes a row under the PID/Name/CPU%/Cmdline columns."""
+        processes = [
+            {"pid": 1, "name": "busy", "cpu_percent": 90.0, "cmdline": "busy --go"},
+            {"pid": 2, "name": "idle", "cpu_percent": 0.1, "cmdline": "idle"},
+        ]
+
+        table = build_process_table(processes, "top_cpu", "CPU")
+
+        assert table.row_count == 2
+        assert [column.header for column in table.columns] == ["PID", "Name", "CPU%", "Cmdline"]
+
+    def test_memory_table_uses_the_memory_columns(self):
+        """The memory ranking swaps the CPU% column for Memory%."""
+        processes = [{"pid": 1, "name": "big", "memory_percent": 50.0, "cmdline": "big"}]
+
+        table = build_process_table(processes, "top_memory", "Memory")
+
+        assert [column.header for column in table.columns] == ["PID", "Name", "Memory%", "Cmdline"]
+
+
+class TestOptionalPanels:
+    def test_gpu_processes_panel_degrades_gracefully(self):
+        """Hosts without GPU compute apps get a message, not a crash."""
+        panel = build_gpu_processes_panel({"top_gpu_processes": []})
+
+        assert "No GPU processes." in str(panel.renderable)
+
+    def test_ollama_panel_degrades_gracefully(self):
+        """An unset or unreachable Ollama renders an empty-state panel."""
+        panel = build_ollama_panel({"ollama_processes": {"models": []}})
+
+        assert "No Ollama models." in str(panel.renderable)
+
+    def test_ollama_panel_lists_loaded_models(self):
+        """Each loaded model becomes a row of the Ollama table."""
+        data = {
+            "ollama_processes": {
+                "models": [
+                    {"name": "llama3", "size": 8 * 1024**3, "size_vram": 4 * 1024**3},
+                    {"name": "qwen3", "size": 4 * 1024**3, "size_vram": 4 * 1024**3},
+                ]
+            }
+        }
+
+        panel = build_ollama_panel(data)
+
+        assert panel.renderable.row_count == 2
+
+    def test_ollama_panel_survives_a_zero_sized_model(self):
+        """A model reporting ``size`` 0 must not raise ZeroDivisionError."""
+        data = {"ollama_processes": {"models": [{"name": "ghost", "size": 0, "size_vram": 0}]}}
+
+        assert build_ollama_panel(data).renderable.row_count == 1

--- a/tests/test_server_collectors.py
+++ b/tests/test_server_collectors.py
@@ -1,0 +1,303 @@
+"""Tests for the metric collectors of :mod:`sys_stats.server`.
+
+The collectors shell out to ``nvidia-smi`` and talk to the Ollama API, so every
+test here replaces those boundaries with fakes. What matters is the parsing and
+the degradation behaviour: a missing GPU or a dead Ollama must yield empty data,
+never an exception, because ``/stats`` has no other error channel.
+"""
+
+import subprocess
+
+import psutil
+import pytest
+import requests
+
+from sys_stats import server
+
+
+class _FakeCompletedProcess:
+    """Minimal stand-in for :class:`subprocess.CompletedProcess`."""
+
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _fake_run(stdout: str):
+    """Build a ``subprocess.run`` replacement returning a fixed stdout."""
+
+    def _run(*args, **kwargs):
+        return _FakeCompletedProcess(stdout)
+
+    return _run
+
+
+def _failing_run(stderr: str = "no devices"):
+    """Build a ``subprocess.run`` replacement raising ``CalledProcessError``."""
+
+    def _run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "nvidia-smi", stderr=stderr)
+
+    return _run
+
+
+class TestGetGpuFanAndPower:
+    def test_parses_one_entry_per_gpu_index(self, monkeypatch):
+        """The CSV output of nvidia-smi is keyed by GPU index."""
+        monkeypatch.setattr(
+            server.subprocess, "run", _fake_run("0, 25, 30.5\n1, 40, 120.0\n")
+        )
+
+        assert server.get_gpu_fan_and_power() == {
+            0: {"fan_speed": 25.0, "power_draw": 30.5},
+            1: {"fan_speed": 40.0, "power_draw": 120.0},
+        }
+
+    def test_skips_malformed_lines(self, monkeypatch):
+        """Cards reporting ``N/A`` (laptop dGPUs, passive cards) are dropped, not fatal."""
+        monkeypatch.setattr(
+            server.subprocess, "run", _fake_run("0, N/A, 30.5\n1, 40, 120.0\n")
+        )
+
+        assert list(server.get_gpu_fan_and_power()) == [1]
+
+    def test_returns_empty_mapping_when_nvidia_smi_fails(self, monkeypatch):
+        """A failing nvidia-smi degrades to no fan/power data at all."""
+        monkeypatch.setattr(server.subprocess, "run", _failing_run())
+
+        assert server.get_gpu_fan_and_power() == {}
+
+
+class TestGetGpuProcesses:
+    @pytest.fixture(autouse=True)
+    def _stub_psutil_process(self, monkeypatch):
+        """Resolve every PID to a fixed command line."""
+
+        class _FakeProcess:
+            def __init__(self, pid):
+                self.pid = pid
+
+            def cmdline(self):
+                return ["python", "train.py"]
+
+        monkeypatch.setattr(server.psutil, "Process", _FakeProcess)
+
+    def test_converts_mib_to_bytes_and_sorts_by_usage(self, monkeypatch):
+        """nvidia-smi reports MiB; ``/stats`` must expose bytes, biggest first."""
+        monkeypatch.setattr(
+            server.subprocess,
+            "run",
+            _fake_run("100, /usr/bin/python3, 512\n200, /opt/ollama/ollama, 2048\n"),
+        )
+
+        processes = server.get_gpu_processes()
+
+        assert [p["pid"] for p in processes] == [200, 100]
+        assert processes[0]["memory_used"] == 2048 * 1024 * 1024
+        assert processes[0]["name"] == "ollama"
+        assert processes[0]["cmdline"] == "python train.py"
+
+    def test_honours_the_limit(self, monkeypatch):
+        """Only the ``limit`` heaviest processes are returned."""
+        monkeypatch.setattr(
+            server.subprocess,
+            "run",
+            _fake_run("1, a, 10\n2, b, 20\n3, c, 30\n"),
+        )
+
+        assert len(server.get_gpu_processes(limit=2)) == 2
+
+    def test_falls_back_to_na_for_vanished_processes(self, monkeypatch):
+        """A PID that died between nvidia-smi and psutil yields ``N/A``, not a crash."""
+
+        def _raise(pid):
+            raise psutil.NoSuchProcess(pid)
+
+        monkeypatch.setattr(server.psutil, "Process", _raise)
+        monkeypatch.setattr(server.subprocess, "run", _fake_run("100, python3, 512\n"))
+
+        assert server.get_gpu_processes()[0]["cmdline"] == "N/A"
+
+    def test_returns_empty_list_when_nvidia_smi_fails(self, monkeypatch):
+        """No GPU compute apps and a broken nvidia-smi look the same to callers."""
+        monkeypatch.setattr(server.subprocess, "run", _failing_run())
+
+        assert server.get_gpu_processes() == []
+
+
+class TestGetOllamaProcess:
+    def test_returns_no_models_when_url_is_unset(self, monkeypatch):
+        """Without ``OLLAMA_API_URL`` the panel stays empty and no request is made."""
+        monkeypatch.setattr(server, "OLLAMA_API_URL", None)
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("no HTTP call expected when OLLAMA_API_URL is unset")
+
+        monkeypatch.setattr(server.requests, "get", _explode)
+
+        assert server.get_ollama_process() == {"models": []}
+
+    def test_queries_the_ps_endpoint_and_returns_the_payload(self, monkeypatch):
+        """The collector hits ``/api/ps`` and passes the JSON straight through."""
+        monkeypatch.setattr(server, "OLLAMA_API_URL", "http://ollama.example:11434")
+        payload = {"models": [{"name": "llama3", "size": 42}]}
+        called = {}
+
+        class _FakeResponse:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return payload
+
+        def _get(url, timeout=None):
+            called["url"] = url
+            return _FakeResponse()
+
+        monkeypatch.setattr(server.requests, "get", _get)
+
+        assert server.get_ollama_process() == payload
+        assert called["url"] == "http://ollama.example:11434/api/ps"
+
+    def test_degrades_to_no_models_when_ollama_is_unreachable(self, monkeypatch):
+        """A dead Ollama must not break the whole ``/stats`` response."""
+        monkeypatch.setattr(server, "OLLAMA_API_URL", "http://ollama.example:11434")
+
+        def _get(*args, **kwargs):
+            raise requests.RequestException("connection refused")
+
+        monkeypatch.setattr(server.requests, "get", _get)
+
+        assert server.get_ollama_process() == {"models": []}
+
+
+class TestTopProcesses:
+    def test_cpu_ranking_is_sorted_and_limited(self, monkeypatch):
+        """Processes come back sorted by CPU usage, truncated to ``limit``."""
+        monkeypatch.setattr(
+            server.psutil,
+            "process_iter",
+            lambda attrs: iter(
+                [
+                    _FakeProcInfo({"pid": 1, "name": "idle", "cpu_percent": 0.5, "cmdline": []}),
+                    _FakeProcInfo(
+                        {"pid": 2, "name": "busy", "cpu_percent": 90.0, "cmdline": ["busy", "--go"]}
+                    ),
+                ]
+            ),
+        )
+
+        top = server.get_top_processes_by_cpu(limit=1)
+
+        assert len(top) == 1
+        assert top[0]["name"] == "busy"
+        assert top[0]["cmdline"] == "busy --go"
+
+    def test_cpu_ranking_reports_na_for_empty_cmdline(self, monkeypatch):
+        """Kernel threads have no command line and must not render as an empty cell."""
+        monkeypatch.setattr(
+            server.psutil,
+            "process_iter",
+            lambda attrs: iter(
+                [_FakeProcInfo({"pid": 1, "name": "kthreadd", "cpu_percent": 1.0, "cmdline": []})]
+            ),
+        )
+
+        assert server.get_top_processes_by_cpu()[0]["cmdline"] == "N/A"
+
+    def test_cpu_ranking_survives_unreadable_attributes(self, monkeypatch):
+        """Regression: ``process_iter`` yields None for denied attributes.
+
+        Sorting None against a float used to raise TypeError and turn the whole
+        ``/stats`` response into a 500 on any unprivileged host (macOS, or a
+        container started without ``pid: host`` and ``privileged``).
+        """
+        monkeypatch.setattr(
+            server.psutil,
+            "process_iter",
+            lambda attrs: iter(
+                [
+                    _FakeProcInfo({"pid": 1, "name": "root-owned", "cpu_percent": None, "cmdline": None}),
+                    _FakeProcInfo({"pid": 2, "name": "mine", "cpu_percent": 5.0, "cmdline": ["mine"]}),
+                ]
+            ),
+        )
+
+        top = server.get_top_processes_by_cpu()
+
+        assert [p["name"] for p in top] == ["mine", "root-owned"]
+        assert top[1]["cpu_percent"] == 0.0
+        assert top[1]["cmdline"] == "N/A"
+
+    def test_memory_ranking_survives_unreadable_attributes(self, monkeypatch):
+        """Regression: a None ``memory_info`` must not raise AttributeError."""
+        monkeypatch.setattr(
+            server.psutil,
+            "process_iter",
+            lambda attrs: iter(
+                [
+                    _FakeProcInfo(
+                        {
+                            "pid": 1,
+                            "name": "root-owned",
+                            "memory_percent": None,
+                            "memory_info": None,
+                            "cmdline": None,
+                        }
+                    ),
+                ]
+            ),
+        )
+
+        top = server.get_top_processes_by_memory()
+
+        assert top[0]["memory_usage"] == 0
+        assert top[0]["memory_percent"] == 0.0
+
+    def test_memory_ranking_exposes_rss_in_bytes(self, monkeypatch):
+        """``memory_usage`` is the RSS in bytes, ranked by percentage."""
+        monkeypatch.setattr(
+            server.psutil,
+            "process_iter",
+            lambda attrs: iter(
+                [
+                    _FakeProcInfo(
+                        {
+                            "pid": 1,
+                            "name": "small",
+                            "memory_percent": 1.0,
+                            "memory_info": _FakeMemoryInfo(1024),
+                            "cmdline": ["small"],
+                        }
+                    ),
+                    _FakeProcInfo(
+                        {
+                            "pid": 2,
+                            "name": "large",
+                            "memory_percent": 50.0,
+                            "memory_info": _FakeMemoryInfo(4096),
+                            "cmdline": ["large"],
+                        }
+                    ),
+                ]
+            ),
+        )
+
+        top = server.get_top_processes_by_memory()
+
+        assert [p["name"] for p in top] == ["large", "small"]
+        assert top[0]["memory_usage"] == 4096
+
+
+class _FakeMemoryInfo:
+    """Stand-in for the ``memory_info`` namedtuple exposed by psutil."""
+
+    def __init__(self, rss: int) -> None:
+        self.rss = rss
+
+
+class _FakeProcInfo:
+    """Stand-in for a :class:`psutil.Process` yielded by ``process_iter``."""
+
+    def __init__(self, info: dict) -> None:
+        self.info = info

--- a/tests/test_stats_endpoint.py
+++ b/tests/test_stats_endpoint.py
@@ -1,0 +1,153 @@
+"""Contract tests for the ``/stats`` payload.
+
+Both consumers (the inline JS dashboard and the Rich CLI) read this JSON, so the
+key names and the units are the actual public API of the project. These tests
+pin them down.
+"""
+
+import pytest
+
+from sys_stats import server
+
+
+class _FakeVirtualMemory:
+    """Stand-in for the namedtuple returned by ``psutil.virtual_memory``."""
+
+    total = 16 * 1024**3
+    used = 8 * 1024**3
+    percent = 50.0
+
+
+class _FakeGPU:
+    """Stand-in for a :class:`GPUtil.GPU`, which reports VRAM in MiB."""
+
+    def __init__(self, gpu_id: int = 0) -> None:
+        self.id = gpu_id
+        self.name = "NVIDIA GeForce RTX 3090"
+        self.load = 0.42
+        self.memoryTotal = 24576
+        self.memoryUsed = 12288
+        self.temperature = 61.0
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A Flask test client with every host-level collector stubbed out."""
+    monkeypatch.setattr(server.psutil, "cpu_percent", lambda interval=None: 12.5)
+    monkeypatch.setattr(server.psutil, "cpu_count", lambda logical=True: 8)
+    monkeypatch.setattr(server.psutil, "virtual_memory", _FakeVirtualMemory)
+    monkeypatch.setattr(server, "get_top_processes_by_cpu", lambda limit=5: [])
+    monkeypatch.setattr(server, "get_top_processes_by_memory", lambda limit=5: [])
+    monkeypatch.setattr(server, "get_ollama_process", lambda: {"models": []})
+    monkeypatch.setattr(server.GPUtil, "getGPUs", lambda: [])
+
+    server.app.config.update(TESTING=True)
+    return server.app.test_client()
+
+
+def test_stats_exposes_the_full_payload_without_a_gpu(client):
+    """On a GPU-less host every GPU section is empty but still present."""
+    payload = client.get("/stats").get_json()
+
+    assert set(payload) == {
+        "current_time",
+        "has_gpu",
+        "summary",
+        "cpu",
+        "ram",
+        "gpu",
+        "top_cpu",
+        "top_memory",
+        "top_gpu_processes",
+        "ollama_processes",
+    }
+    assert payload["has_gpu"] is False
+    assert payload["gpu"] == []
+    assert payload["top_gpu_processes"] == []
+    assert payload["summary"]["gpu"] == []
+    assert payload["cpu"] == 12.5
+    assert payload["ram"] == {"total": 16 * 1024**3, "used": 8 * 1024**3, "percent": 50.0}
+
+
+def test_stats_converts_gpu_memory_to_bytes(client, monkeypatch):
+    """GPUtil reports MiB; the payload must carry bytes and a percentage."""
+    monkeypatch.setattr(server.GPUtil, "getGPUs", lambda: [_FakeGPU()])
+    monkeypatch.setattr(
+        server, "get_gpu_fan_and_power", lambda: {0: {"fan_speed": 30.0, "power_draw": 220.0}}
+    )
+    monkeypatch.setattr(server, "get_gpu_processes", lambda limit=5: [])
+
+    gpu = client.get("/stats").get_json()["gpu"][0]
+
+    assert gpu["memoryUsed"] == 12288 * 1024 * 1024
+    assert gpu["memoryTotal"] == 24576  # still MiB, as GPUtil reports it
+    assert gpu["memoryPercent"] == pytest.approx(50.0)
+    assert gpu["load"] == pytest.approx(42.0)  # fraction scaled to a percentage
+    assert gpu["fanSpeed"] == 30.0
+    assert gpu["powerDraw"] == 220.0
+
+
+def test_stats_summary_mirrors_the_first_gpu(client, monkeypatch):
+    """The summary block is a condensed view of GPU 0 for the compact panels."""
+    monkeypatch.setattr(server.GPUtil, "getGPUs", lambda: [_FakeGPU()])
+    monkeypatch.setattr(server, "get_gpu_fan_and_power", lambda: {})
+    monkeypatch.setattr(server, "get_gpu_processes", lambda limit=5: [])
+
+    summary = client.get("/stats").get_json()["summary"]
+
+    assert summary["cpu"] == {"usage": 12.5, "cores": 8}
+    assert summary["gpu"][0]["name"] == "NVIDIA GeForce RTX 3090"
+    assert summary["gpu"][0]["vram"] == pytest.approx(50.0)
+
+
+def test_stats_defaults_to_zero_fan_and_power_when_nvidia_smi_is_silent(client, monkeypatch):
+    """Missing fan/power data must not drop the GPU from the payload."""
+    monkeypatch.setattr(server.GPUtil, "getGPUs", lambda: [_FakeGPU()])
+    monkeypatch.setattr(server, "get_gpu_fan_and_power", lambda: {})
+    monkeypatch.setattr(server, "get_gpu_processes", lambda limit=5: [])
+
+    gpu = client.get("/stats").get_json()["gpu"][0]
+
+    assert gpu["fanSpeed"] == 0.0
+    assert gpu["powerDraw"] == 0.0
+
+
+def test_stats_forwards_the_limit_query_parameter(client, monkeypatch):
+    """``?limit=`` controls how many processes each ranking returns."""
+    seen = {}
+    monkeypatch.setattr(
+        server, "get_top_processes_by_cpu", lambda limit=5: seen.setdefault("cpu", limit) and []
+    )
+
+    client.get("/stats?limit=3")
+
+    assert seen["cpu"] == 3
+
+
+def test_stats_falls_back_to_five_on_a_non_numeric_limit(client, monkeypatch):
+    """A bogus ``limit`` is ignored rather than returning a 500."""
+    seen = {}
+    monkeypatch.setattr(
+        server, "get_top_processes_by_cpu", lambda limit=5: seen.setdefault("cpu", limit) and []
+    )
+
+    response = client.get("/stats?limit=banana")
+
+    assert response.status_code == 200
+    assert seen["cpu"] == 5
+
+
+def test_index_serves_the_dashboard(client):
+    """The web UI is served from the packaged template directory."""
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"<html" in response.data.lower()
+
+
+def test_favicon_is_packaged_alongside_the_template(client):
+    """``/favicon.png`` is served from inside the installed package."""
+    response = client.get("/favicon.png")
+
+    assert response.status_code == 200
+    assert response.mimetype == "image/png"


### PR DESCRIPTION
Adds the test tooling this repo never had, and fixes the three bugs the tests turned up.

## Tooling

- `[dev]` extra with pytest and ruff, so `uv pip install -e '.[dev]'` gets you a working dev env
- pytest `testpaths` and a ruff config (line length 120, py310 target, E/F/W/I/UP/B)
- `.gitignore` fix: `/__pycache__` only ever matched the repo root, so nested caches were showing up in `git status`

## Tests

51 tests, none of which touch the real machine. `psutil`, `GPUtil`, `subprocess.run` and `requests.get` are all monkeypatched at the `sys_stats.server` boundary, so the suite gives the same result on a GPU box, on a laptop, and in CI.

- `tests/test_stats_endpoint.py` is the contract test for the `/stats` payload: key names, the MiB to bytes conversion, the load fraction to percentage conversion, the summary block
- `tests/test_server_collectors.py` covers the nvidia-smi CSV parsing (including malformed lines, which real cards do emit) and the degradation paths when nvidia-smi or Ollama are missing
- `tests/test_cli_formatting.py` and `tests/test_cli_panels.py` cover the formatting helpers and the Rich panel builders

## Bugs found and fixed

**`/stats` returned a 500 on any unprivileged host.** `psutil.process_iter(attrs)` does not raise when it cannot read an attribute, it silently fills it with `None`. That is the normal case for root-owned processes, so `processes.sort(key=lambda x: x["cpu_percent"])` compared `None` against a float and blew up the whole endpoint. Reproducible on macOS out of the box, and in any container started without `pid: host` and `privileged`. Percentages now default to 0 and a missing `memory_info` no longer gets dereferenced.

**`human_readable_size` under-reported anything past a terabyte.** `TB` was listed inside the conversion loop, so the loop divided once more before falling through to the `TB` fallback: 5 PB rendered as `5.0 TB`.

**The GPU summary panel showed card 0 N times.** `build_gpu_summary` iterated over every GPU but reassigned `gpu_data = data['gpu'][0]` on each pass, so a multi-GPU host got the first card repeated instead of one table per card.

Each of the three has a regression test, and I checked they actually fail against the unfixed code rather than just passing by accident.

## Also

- `CLAUDE.md` documenting the `/stats` contract as the thing that couples the web UI and the CLI, the CLI threading model, and the testing conventions
- README notes on the `[dev]` extra and on macOS grabbing port 5000 for AirPlay Receiver

## Verification

`pytest` green (51 passed), `ruff check .` clean, and a real smoke test of the server: 200 on `/stats`, `/` and `/favicon.png` where `/stats` used to 500.


## CI

The workflow only built the Docker image, so nothing stopped a broken commit from reaching the registry. It now runs `ruff check` and `pytest` on Python 3.10, 3.12 and 3.13 first, and `build-and-push` depends on that job. Lint runs on a single matrix entry since it does not depend on the interpreter version. Renamed the workflow to `CI` now that it does more than build.
